### PR TITLE
feat: Task 1.3 — Configure Permissions in AndroidManifest

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -24,7 +24,7 @@ Mark tasks `[x]` when complete. Do not skip tasks — later tasks depend on earl
     - `kotlinx.coroutines` (android)
   - Sync and confirm build passes with no errors
 
-- [ ] **Task 1.3 — Configure Permissions in AndroidManifest**
+- [x] **Task 1.3 — Configure Permissions in AndroidManifest**
   - Add `PACKAGE_USAGE_STATS` permission
   - Add `FOREGROUND_SERVICE` permission
   - Add `RECEIVE_BOOT_COMPLETED` permission

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.PACKAGE_USAGE_STATS"
+        tools:ignore="ProtectedPermissions"
+        xmlns:tools="http://schemas.android.com/tools" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+
     <application
         android:allowBackup="true"
         android:label="@string/app_name"
@@ -16,6 +22,18 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <receiver
+            android:name=".BootReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
+
+        <service
+            android:name=".UsageTrackingService"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/brainrotrpg/BootReceiver.kt
+++ b/app/src/main/java/com/brainrotrpg/BootReceiver.kt
@@ -1,0 +1,11 @@
+package com.brainrotrpg
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+class BootReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        // TODO (Task 4.4): Call WorkScheduler.schedulePeriodicTracking(context) here
+    }
+}

--- a/app/src/main/java/com/brainrotrpg/UsageTrackingService.kt
+++ b/app/src/main/java/com/brainrotrpg/UsageTrackingService.kt
@@ -1,0 +1,15 @@
+package com.brainrotrpg
+
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+
+class UsageTrackingService : Service() {
+
+    override fun onBind(intent: Intent): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        // TODO (Task 4.1): Implement usage tracking logic via UsageTrackingWorker
+        return START_NOT_STICKY
+    }
+}


### PR DESCRIPTION
Implements Task 1.3 from TASKS.md:

- Add PACKAGE_USAGE_STATS, FOREGROUND_SERVICE, and RECEIVE_BOOT_COMPLETED permissions
- Register BootReceiver placeholder with BOOT_COMPLETED intent filter
- Register UsageTrackingService placeholder in AndroidManifest.xml
- Create BootReceiver.kt and UsageTrackingService.kt stub implementations

Closes #7

Generated with [Claude Code](https://claude.ai/code)