### PR TITLE
feat: Task 2.1 — Permission Check & Deep Link

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -35,7 +35,7 @@ Mark tasks `[x]` when complete. Do not skip tasks — later tasks depend on earl
 
 ## Phase 2: Usage Tracking
 
-- [ ] **Task 2.1 — Permission Check & Deep Link**
+- [x] **Task 2.1 — Permission Check & Deep Link**
   - Create `UsagePermissionHelper.kt`
   - Function: `hasUsagePermission(context): Boolean` — checks if `PACKAGE_USAGE_STATS` is granted
   - Function: `openUsageAccessSettings(context)` — deep links to Settings > Special App Access > Usage Access

--- a/app/src/main/java/com/brainrotrpg/UsagePermissionHelper.kt
+++ b/app/src/main/java/com/brainrotrpg/UsagePermissionHelper.kt
@@ -1,0 +1,28 @@
+package com.brainrotrpg
+
+import android.app.AppOpsManager
+import android.content.Context
+import android.content.Intent
+import android.os.Process
+import android.provider.Settings
+
+object UsagePermissionHelper {
+
+    fun hasUsagePermission(context: Context): Boolean {
+        val appOpsManager = context.getSystemService(Context.APP_OPS_SERVICE) as AppOpsManager
+        val mode = appOpsManager.checkOpNoThrow(
+            AppOpsManager.OPSTR_GET_USAGE_STATS,
+            Process.myUid(),
+            context.packageName
+        )
+        return isModeAllowed(mode)
+    }
+
+    fun openUsageAccessSettings(context: Context) {
+        val intent = Intent(Settings.ACTION_USAGE_ACCESS_SETTINGS)
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        context.startActivity(intent)
+    }
+
+    internal fun isModeAllowed(mode: Int): Boolean = mode == AppOpsManager.MODE_ALLOWED
+}

--- a/app/src/test/java/com/brainrotrpg/UsagePermissionHelperTest.kt
+++ b/app/src/test/java/com/brainrotrpg/UsagePermissionHelperTest.kt
@@ -1,0 +1,23 @@
+package com.brainrotrpg
+
+import android.app.AppOpsManager
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UsagePermissionHelperTest {
+
+    @Test
+    fun `isModeAllowed returns false when mode is not MODE_ALLOWED`() {
+        // AppOpsManager.MODE_DEFAULT (2), MODE_IGNORED (1), MODE_ERRORED (3) all indicate
+        // the permission is not granted.
+        assertFalse(UsagePermissionHelper.isModeAllowed(AppOpsManager.MODE_DEFAULT))
+        assertFalse(UsagePermissionHelper.isModeAllowed(AppOpsManager.MODE_IGNORED))
+        assertFalse(UsagePermissionHelper.isModeAllowed(AppOpsManager.MODE_ERRORED))
+    }
+
+    @Test
+    fun `isModeAllowed returns true when mode is MODE_ALLOWED`() {
+        assertTrue(UsagePermissionHelper.isModeAllowed(AppOpsManager.MODE_ALLOWED))
+    }
+}


### PR DESCRIPTION
Implements Task 2.1 from TASKS.md:

- Add `UsagePermissionHelper.kt` with `hasUsagePermission()` and `openUsageAccessSettings()`
- Add unit tests covering all non-granted AppOps modes
- Mark Task 2.1 complete in TASKS.md

Closes #9

Generated with [Claude Code](https://claude.ai/code)