### PR TITLE
feat: Task 2.2 - App Category Map

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -41,7 +41,7 @@ Mark tasks `[x]` when complete. Do not skip tasks — later tasks depend on earl
   - Function: `openUsageAccessSettings(context)` — deep links to Settings > Special App Access > Usage Access
   - Write a unit test confirming the permission check returns false when not granted
 
-- [ ] **Task 2.2 — App Category Map**
+- [x] **Task 2.2 — App Category Map**
   - Create `AppCategories.kt`
   - Define a `Category` enum: `BRAINROT`, `MID`, `ENRICHMENT`, `UNTRACKED`
   - Define a `packageCategoryMap: Map<String, Category>` with at least:

--- a/app/src/main/java/com/brainrotrpg/AppCategories.kt
+++ b/app/src/main/java/com/brainrotrpg/AppCategories.kt
@@ -1,0 +1,24 @@
+package com.brainrotrpg
+
+enum class Category {
+    BRAINROT,
+    MID,
+    ENRICHMENT,
+    UNTRACKED
+}
+
+val packageCategoryMap: Map<String, Category> = mapOf(
+    "com.zhiliaoapp.musically" to Category.BRAINROT,       // TikTok
+    "com.instagram.android" to Category.BRAINROT,          // Instagram
+
+    "com.google.android.youtube" to Category.MID,          // YouTube
+    "com.twitter.android" to Category.MID,                 // Twitter/X
+    "com.reddit.frontpage" to Category.MID,                // Reddit
+
+    "com.spotify.music" to Category.ENRICHMENT,            // Spotify
+    "com.audible.application" to Category.ENRICHMENT,      // Audible
+    "com.google.android.apps.podcasts" to Category.ENRICHMENT  // Google Podcasts
+)
+
+fun getCategory(packageName: String): Category =
+    packageCategoryMap[packageName] ?: Category.UNTRACKED

--- a/app/src/test/java/com/brainrotrpg/AppCategoriesTest.kt
+++ b/app/src/test/java/com/brainrotrpg/AppCategoriesTest.kt
@@ -1,0 +1,52 @@
+package com.brainrotrpg
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AppCategoriesTest {
+
+    @Test
+    fun `TikTok package returns BRAINROT`() {
+        assertEquals(Category.BRAINROT, getCategory("com.zhiliaoapp.musically"))
+    }
+
+    @Test
+    fun `Instagram package returns BRAINROT`() {
+        assertEquals(Category.BRAINROT, getCategory("com.instagram.android"))
+    }
+
+    @Test
+    fun `YouTube package returns MID`() {
+        assertEquals(Category.MID, getCategory("com.google.android.youtube"))
+    }
+
+    @Test
+    fun `Twitter package returns MID`() {
+        assertEquals(Category.MID, getCategory("com.twitter.android"))
+    }
+
+    @Test
+    fun `Reddit package returns MID`() {
+        assertEquals(Category.MID, getCategory("com.reddit.frontpage"))
+    }
+
+    @Test
+    fun `Spotify package returns ENRICHMENT`() {
+        assertEquals(Category.ENRICHMENT, getCategory("com.spotify.music"))
+    }
+
+    @Test
+    fun `Audible package returns ENRICHMENT`() {
+        assertEquals(Category.ENRICHMENT, getCategory("com.audible.application"))
+    }
+
+    @Test
+    fun `Google Podcasts package returns ENRICHMENT`() {
+        assertEquals(Category.ENRICHMENT, getCategory("com.google.android.apps.podcasts"))
+    }
+
+    @Test
+    fun `Unknown package returns UNTRACKED`() {
+        assertEquals(Category.UNTRACKED, getCategory("com.unknown.app"))
+    }
+}


### PR DESCRIPTION
Implements Task 2.2 from TASKS.md:

- Add `Category` enum (BRAINROT, MID, ENRICHMENT, UNTRACKED)
- Add `packageCategoryMap` with all required package mappings
- Add `getCategory()` helper function
- Add 9 unit tests covering all known packages and unknown fallback

Closes #11

Generated with [Claude Code](https://claude.ai/code)