### PR TITLE
feat: implement UsageStatsManager reader (Task 2.3)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -50,7 +50,7 @@ Mark tasks `[x]` when complete. Do not skip tasks — later tasks depend on earl
     - Spotify, Audible, Google Podcasts → ENRICHMENT
   - Write a unit test confirming known packages return the correct category
 
-- [ ] **Task 2.3 — UsageStatsManager Reader**
+- [x] **Task 2.3 — UsageStatsManager Reader**
   - Create `UsageStatsReader.kt`
   - Function: `getUsageSince(context, sinceMillis): Map<String, Long>`
     - Returns map of packageName → foregroundTimeMillis for all apps used since `sinceMillis`

--- a/app/src/main/java/com/brainrotrpg/UsageStatsReader.kt
+++ b/app/src/main/java/com/brainrotrpg/UsageStatsReader.kt
@@ -1,0 +1,44 @@
+package com.brainrotrpg
+
+import android.app.usage.UsageStatsManager
+import android.content.Context
+import android.util.Log
+
+object UsageStatsReader {
+
+    private const val TAG = "UsageStatsReader"
+
+    fun getUsageSince(context: Context, sinceMillis: Long): Map<String, Long> {
+        if (!UsagePermissionHelper.hasUsagePermission(context)) {
+            Log.w(TAG, "Usage stats permission not granted. Returning empty map.")
+            return emptyMap()
+        }
+
+        val usageStatsManager = context.getSystemService(Context.USAGE_STATS_SERVICE) as UsageStatsManager
+        val now = System.currentTimeMillis()
+        val usageStats = usageStatsManager.queryUsageStats(
+            UsageStatsManager.INTERVAL_BEST,
+            sinceMillis,
+            now
+        ) ?: return emptyMap()
+
+        return usageStats
+            .filter { it.totalTimeInForeground > 0 }
+            .groupingBy { it.packageName }
+            .fold(0L) { acc, stats -> acc + stats.totalTimeInForeground }
+    }
+
+    fun getCategorizedUsage(context: Context, sinceMillis: Long): Map<Category, Long> {
+        val usageMap = getUsageSince(context, sinceMillis)
+        return aggregateCategorizedUsage(usageMap)
+    }
+
+    internal fun aggregateCategorizedUsage(usageMap: Map<String, Long>): Map<Category, Long> {
+        val result = mutableMapOf<Category, Long>()
+        for ((packageName, durationMillis) in usageMap) {
+            val category = getCategory(packageName)
+            result[category] = (result[category] ?: 0L) + durationMillis
+        }
+        return result
+    }
+}

--- a/app/src/test/java/com/brainrotrpg/UsageStatsReaderTest.kt
+++ b/app/src/test/java/com/brainrotrpg/UsageStatsReaderTest.kt
@@ -1,0 +1,71 @@
+package com.brainrotrpg
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UsageStatsReaderTest {
+
+    @Test
+    fun `aggregateCategorizedUsage returns empty map for empty input`() {
+        val result = UsageStatsReader.aggregateCategorizedUsage(emptyMap())
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `aggregateCategorizedUsage correctly categorizes brainrot apps`() {
+        val usageMap = mapOf(
+            "com.zhiliaoapp.musically" to 60_000L,  // TikTok - 1 min
+            "com.instagram.android" to 120_000L     // Instagram - 2 min
+        )
+        val result = UsageStatsReader.aggregateCategorizedUsage(usageMap)
+        assertEquals(180_000L, result[Category.BRAINROT])
+    }
+
+    @Test
+    fun `aggregateCategorizedUsage correctly categorizes mid apps`() {
+        val usageMap = mapOf(
+            "com.google.android.youtube" to 300_000L,  // YouTube - 5 min
+            "com.twitter.android" to 60_000L,          // Twitter - 1 min
+            "com.reddit.frontpage" to 120_000L         // Reddit - 2 min
+        )
+        val result = UsageStatsReader.aggregateCategorizedUsage(usageMap)
+        assertEquals(480_000L, result[Category.MID])
+    }
+
+    @Test
+    fun `aggregateCategorizedUsage correctly categorizes enrichment apps`() {
+        val usageMap = mapOf(
+            "com.spotify.music" to 3_600_000L,                 // Spotify - 1 hour
+            "com.audible.application" to 1_800_000L,           // Audible - 30 min
+            "com.google.android.apps.podcasts" to 900_000L     // Podcasts - 15 min
+        )
+        val result = UsageStatsReader.aggregateCategorizedUsage(usageMap)
+        assertEquals(6_300_000L, result[Category.ENRICHMENT])
+    }
+
+    @Test
+    fun `aggregateCategorizedUsage places unknown packages in UNTRACKED`() {
+        val usageMap = mapOf(
+            "com.unknown.app" to 60_000L,
+            "com.another.unknown" to 30_000L
+        )
+        val result = UsageStatsReader.aggregateCategorizedUsage(usageMap)
+        assertEquals(90_000L, result[Category.UNTRACKED])
+    }
+
+    @Test
+    fun `aggregateCategorizedUsage correctly aggregates mixed categories`() {
+        val usageMap = mapOf(
+            "com.zhiliaoapp.musically" to 600_000L,    // TikTok - BRAINROT
+            "com.spotify.music" to 3_600_000L,         // Spotify - ENRICHMENT
+            "com.google.android.youtube" to 1_800_000L, // YouTube - MID
+            "com.unknown.app" to 60_000L               // Unknown - UNTRACKED
+        )
+        val result = UsageStatsReader.aggregateCategorizedUsage(usageMap)
+        assertEquals(600_000L, result[Category.BRAINROT])
+        assertEquals(3_600_000L, result[Category.ENRICHMENT])
+        assertEquals(1_800_000L, result[Category.MID])
+        assertEquals(60_000L, result[Category.UNTRACKED])
+    }
+}


### PR DESCRIPTION
Implements Task 2.3 from TASKS.md.

- Add `UsageStatsReader.kt` with `getUsageSince` and `getCategorizedUsage` functions
- `getUsageSince` queries UsageStatsManager for per-app foreground time since a given timestamp
- `getCategorizedUsage` maps package names through AppCategories and sums by category
- Returns empty map and logs a warning when permission is not granted
- Add unit tests for aggregation logic
- Mark Task 2.3 as complete in TASKS.md

Closes #13

Generated with [Claude Code](https://claude.ai/code)