### PR TITLE
feat: Task 2.4 — Mock Data Layer

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -58,7 +58,7 @@ Mark tasks `[x]` when complete. Do not skip tasks — later tasks depend on earl
     - Calls `getUsageSince`, maps packages through `AppCategories`, sums by category
   - Handle the case where permission is not granted (return empty map, log warning)
 
-- [ ] **Task 2.4 — Mock Data Layer**
+- [x] **Task 2.4 — Mock Data Layer**
   - Create `MockUsageStatsReader.kt`
   - Implements the same interface as `UsageStatsReader`
   - Returns hardcoded fake data (e.g. 3 hours TikTok, 1 hour Spotify)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,12 +20,16 @@ android {
     }
 
     buildTypes {
+        debug {
+            buildConfigField("boolean", "USE_MOCK_DATA", "true")
+        }
         release {
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            buildConfigField("boolean", "USE_MOCK_DATA", "false")
         }
     }
     compileOptions {
@@ -37,6 +41,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 }
 

--- a/app/src/main/java/com/brainrotrpg/MockUsageStatsReader.kt
+++ b/app/src/main/java/com/brainrotrpg/MockUsageStatsReader.kt
@@ -1,0 +1,22 @@
+package com.brainrotrpg
+
+import android.content.Context
+
+object MockUsageStatsReader : IUsageStatsReader {
+
+    // Hardcoded fake usage data for development and testing:
+    // 3 hours TikTok (BRAINROT), 1 hour Spotify (ENRICHMENT), 30 min YouTube (MID)
+    private val mockPackageUsage: Map<String, Long> = mapOf(
+        "com.zhiliaoapp.musically" to 3L * 60 * 60 * 1000,  // 3 hours TikTok
+        "com.spotify.music" to 1L * 60 * 60 * 1000,          // 1 hour Spotify
+        "com.google.android.youtube" to 30L * 60 * 1000       // 30 min YouTube
+    )
+
+    override fun getUsageSince(context: Context, sinceMillis: Long): Map<String, Long> {
+        return mockPackageUsage
+    }
+
+    override fun getCategorizedUsage(context: Context, sinceMillis: Long): Map<Category, Long> {
+        return UsageStatsReader.aggregateCategorizedUsage(mockPackageUsage)
+    }
+}

--- a/app/src/main/java/com/brainrotrpg/UsageStatsReader.kt
+++ b/app/src/main/java/com/brainrotrpg/UsageStatsReader.kt
@@ -4,11 +4,11 @@ import android.app.usage.UsageStatsManager
 import android.content.Context
 import android.util.Log
 
-object UsageStatsReader {
+object UsageStatsReader : IUsageStatsReader {
 
     private const val TAG = "UsageStatsReader"
 
-    fun getUsageSince(context: Context, sinceMillis: Long): Map<String, Long> {
+    override fun getUsageSince(context: Context, sinceMillis: Long): Map<String, Long> {
         if (!UsagePermissionHelper.hasUsagePermission(context)) {
             Log.w(TAG, "Usage stats permission not granted. Returning empty map.")
             return emptyMap()
@@ -28,7 +28,7 @@ object UsageStatsReader {
             .fold(0L) { acc, stats -> acc + stats.totalTimeInForeground }
     }
 
-    fun getCategorizedUsage(context: Context, sinceMillis: Long): Map<Category, Long> {
+    override fun getCategorizedUsage(context: Context, sinceMillis: Long): Map<Category, Long> {
         val usageMap = getUsageSince(context, sinceMillis)
         return aggregateCategorizedUsage(usageMap)
     }

--- a/app/src/main/java/com/brainrotrpg/UsageStatsReaderInterface.kt
+++ b/app/src/main/java/com/brainrotrpg/UsageStatsReaderInterface.kt
@@ -1,0 +1,8 @@
+package com.brainrotrpg
+
+import android.content.Context
+
+interface IUsageStatsReader {
+    fun getUsageSince(context: Context, sinceMillis: Long): Map<String, Long>
+    fun getCategorizedUsage(context: Context, sinceMillis: Long): Map<Category, Long>
+}

--- a/app/src/main/java/com/brainrotrpg/UsageStatsReaderProvider.kt
+++ b/app/src/main/java/com/brainrotrpg/UsageStatsReaderProvider.kt
@@ -1,0 +1,6 @@
+package com.brainrotrpg
+
+object UsageStatsReaderProvider {
+    val instance: IUsageStatsReader
+        get() = if (BuildConfig.USE_MOCK_DATA) MockUsageStatsReader else UsageStatsReader
+}


### PR DESCRIPTION
Implements Task 2.4 from TASKS.md: Mock Data Layer

- Add IUsageStatsReader interface
- Create MockUsageStatsReader with hardcoded fake data
- Create UsageStatsReaderProvider controlled by BuildConfig.USE_MOCK_DATA

Closes #15

Generated with [Claude Code](https://claude.ai/code)