### PR TITLE
feat: Add Room entities for UsageRecord and PlayerStats (Task 3.1)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -69,7 +69,7 @@ Mark tasks `[x]` when complete. Do not skip tasks — later tasks depend on earl
 
 ## Phase 3: Local Database (Room)
 
-- [ ] **Task 3.1 — Define Room Entities**
+- [x] **Task 3.1 — Define Room Entities**
   - Create `UsageRecord.kt` — entity with fields: `id`, `timestamp`, `category`, `durationMillis`
   - Create `PlayerStats.kt` — entity with fields: `id` (singleton, always 1), `totalXp`, `level`, `brainrotHours`, `midHours`, `enrichmentHours`, `lastCheckedTimestamp`
 

--- a/app/src/main/java/com/brainrotrpg/PlayerStats.kt
+++ b/app/src/main/java/com/brainrotrpg/PlayerStats.kt
@@ -1,0 +1,16 @@
+package com.brainrotrpg
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "player_stats")
+data class PlayerStats(
+    @PrimaryKey
+    val id: Int = 1, // Singleton row — always 1
+    val totalXp: Long,
+    val level: Int,
+    val brainrotHours: Float,
+    val midHours: Float,
+    val enrichmentHours: Float,
+    val lastCheckedTimestamp: Long
+)

--- a/app/src/main/java/com/brainrotrpg/UsageRecord.kt
+++ b/app/src/main/java/com/brainrotrpg/UsageRecord.kt
@@ -1,0 +1,13 @@
+package com.brainrotrpg
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "usage_records")
+data class UsageRecord(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val timestamp: Long,
+    val category: String, // Stores Category.name (e.g. "BRAINROT", "MID", "ENRICHMENT")
+    val durationMillis: Long
+)


### PR DESCRIPTION
Implements Task 3.1 from TASKS.md.

## Changes
- Added `UsageRecord.kt` Room entity with id, timestamp, category, durationMillis
- Added `PlayerStats.kt` Room entity with id (singleton=1), totalXp, level, brainrotHours, midHours, enrichmentHours, lastCheckedTimestamp
- Marked Task 3.1 complete in TASKS.md

Closes #17

Generated with [Claude Code](https://claude.ai/code)