### PR TITLE
feat: Task 4.3 - Schedule WorkManager Job

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -108,7 +108,7 @@ Mark tasks `[x]` when complete. Do not skip tasks — later tasks depend on earl
     - Simple threshold table: Level 1 = 0 XP, Level 2 = 500 XP, Level 3 = 1200 XP, etc.
   - Write unit tests for both functions with known inputs/outputs
 
-- [ ] **Task 4.3 — Schedule WorkManager Job**
+- [x] **Task 4.3 — Schedule WorkManager Job**
   - Create `WorkScheduler.kt`
   - Function: `schedulePeriodicTracking(context)`
     - Uses `PeriodicWorkRequestBuilder` with 15-minute interval

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
+        android:name=".BrainRotApp"
         android:allowBackup="true"
         android:label="@string/app_name"
         android:supportsRtl="true"

--- a/app/src/main/java/com/brainrotrpg/BrainRotApp.kt
+++ b/app/src/main/java/com/brainrotrpg/BrainRotApp.kt
@@ -1,0 +1,10 @@
+package com.brainrotrpg
+
+import android.app.Application
+
+class BrainRotApp : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        WorkScheduler.schedulePeriodicTracking(this)
+    }
+}

--- a/app/src/main/java/com/brainrotrpg/WorkScheduler.kt
+++ b/app/src/main/java/com/brainrotrpg/WorkScheduler.kt
@@ -1,0 +1,23 @@
+package com.brainrotrpg
+
+import android.content.Context
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import java.util.concurrent.TimeUnit
+
+object WorkScheduler {
+
+    private const val WORK_NAME = "UsageTrackingWork"
+
+    fun schedulePeriodicTracking(context: Context) {
+        val request = PeriodicWorkRequestBuilder<UsageTrackingWorker>(15, TimeUnit.MINUTES)
+            .build()
+
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+            WORK_NAME,
+            ExistingPeriodicWorkPolicy.KEEP,
+            request
+        )
+    }
+}


### PR DESCRIPTION
Implements Task 4.3 from TASKS.md:

- Add WorkScheduler.kt with schedulePeriodicTracking() using 15-minute PeriodicWorkRequest and ExistingPeriodicWorkPolicy.KEEP
- Add BrainRotApp Application subclass that schedules tracking on onCreate
- Register BrainRotApp in AndroidManifest.xml

Closes #27

Generated with [Claude Code](https://claude.ai/code)