### PR TITLE
feat: implement BootReceiver (Task 4.4)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -116,7 +116,7 @@ Mark tasks `[x]` when complete. Do not skip tasks — later tasks depend on earl
   - Call `schedulePeriodicTracking` from `Application.onCreate()`
   - Create `Application` subclass and register it in `AndroidManifest.xml`
 
-- [ ] **Task 4.4 — Boot Receiver**
+- [x] **Task 4.4 — Boot Receiver**
   - Create `BootReceiver.kt` extending `BroadcastReceiver`
   - On `BOOT_COMPLETED` intent, call `WorkScheduler.schedulePeriodicTracking(context)`
   - Register in manifest with `RECEIVE_BOOT_COMPLETED` intent filter

--- a/app/src/main/java/com/brainrotrpg/BootReceiver.kt
+++ b/app/src/main/java/com/brainrotrpg/BootReceiver.kt
@@ -6,6 +6,8 @@ import android.content.Intent
 
 class BootReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
-        // TODO (Task 4.4): Call WorkScheduler.schedulePeriodicTracking(context) here
+        if (intent.action == Intent.ACTION_BOOT_COMPLETED) {
+            WorkScheduler.schedulePeriodicTracking(context)
+        }
     }
 }


### PR DESCRIPTION
Implements Task 4.4 from TASKS.md.

- Fills in `BootReceiver.onReceive` to call `WorkScheduler.schedulePeriodicTracking` on `BOOT_COMPLETED`
- Ensures background usage tracking resumes after device reboot

Closes #29

Generated with [Claude Code](https://claude.ai/code)