### PR TITLE
feat: implement AvatarViewModel (Task 5.3)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -142,7 +142,7 @@ Mark tasks `[x]` when complete. Do not skip tasks — later tasks depend on earl
   - Place in `res/drawable/`
   - These are replaced with real art post-MVP — placeholders are fine for now
 
-- [ ] **Task 5.3 — AvatarViewModel**
+- [x] **Task 5.3 — AvatarViewModel**
   - Create `AvatarViewModel.kt` extending `ViewModel`
   - Expose a `StateFlow<AvatarUiState>` where `AvatarUiState` contains:
     - `level: Int`

--- a/app/src/main/java/com/brainrotrpg/AvatarViewModel.kt
+++ b/app/src/main/java/com/brainrotrpg/AvatarViewModel.kt
@@ -1,0 +1,53 @@
+package com.brainrotrpg
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+data class AvatarUiState(
+    val level: Int = 1,
+    val totalXp: Long = 0L,
+    val xpToNextLevel: Long = 500L,
+    val avatarState: AvatarState = AvatarState.Hybrid,
+    val brainrotHours: Float = 0f,
+    val midHours: Float = 0f,
+    val enrichmentHours: Float = 0f
+)
+
+class AvatarViewModel(
+    private val playerStatsDao: PlayerStatsDao
+) : ViewModel() {
+
+    val uiState: StateFlow<AvatarUiState> = playerStatsDao.observeStats()
+        .map { stats -> stats?.toUiState() ?: AvatarUiState() }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = AvatarUiState()
+        )
+
+    private fun PlayerStats.toUiState(): AvatarUiState = AvatarUiState(
+        level = level,
+        totalXp = totalXp,
+        xpToNextLevel = XpEngine.xpToNextLevel(totalXp),
+        avatarState = resolveAvatarState(brainrotHours, midHours, enrichmentHours),
+        brainrotHours = brainrotHours,
+        midHours = midHours,
+        enrichmentHours = enrichmentHours
+    )
+
+    companion object {
+        fun factory(playerStatsDao: PlayerStatsDao): ViewModelProvider.Factory =
+            viewModelFactory {
+                initializer {
+                    AvatarViewModel(playerStatsDao)
+                }
+            }
+    }
+}

--- a/app/src/main/java/com/brainrotrpg/PlayerStatsDao.kt
+++ b/app/src/main/java/com/brainrotrpg/PlayerStatsDao.kt
@@ -3,12 +3,16 @@ package com.brainrotrpg
 import androidx.room.Dao
 import androidx.room.Query
 import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface PlayerStatsDao {
 
     @Query("SELECT * FROM player_stats WHERE id = 1")
     suspend fun getStats(): PlayerStats?
+
+    @Query("SELECT * FROM player_stats WHERE id = 1")
+    fun observeStats(): Flow<PlayerStats?>
 
     @Upsert
     suspend fun upsert(stats: PlayerStats)

--- a/app/src/main/java/com/brainrotrpg/XpEngine.kt
+++ b/app/src/main/java/com/brainrotrpg/XpEngine.kt
@@ -33,4 +33,10 @@ object XpEngine {
         }
         return level
     }
+
+    fun xpToNextLevel(totalXp: Long): Long {
+        val level = calculateLevel(totalXp)
+        return if (level >= LEVEL_THRESHOLDS.size) 0L
+        else LEVEL_THRESHOLDS[level] - totalXp
+    }
 }


### PR DESCRIPTION
Implements Task 5.3 from TASKS.md.

## Changes
- Add `AvatarUiState` data class with level, totalXp, xpToNextLevel, avatarState, and hours fields
- Add `AvatarViewModel` exposing `StateFlow<AvatarUiState>` from `PlayerStatsDao`
- Add `observeStats()` Flow query to `PlayerStatsDao` for live data updates
- Add `xpToNextLevel()` helper to `XpEngine`
- Add `ViewModelProvider.Factory` companion for dependency injection

Closes #35

Generated with [Claude Code](https://claude.ai/code)