### PR TITLE
feat: Task 6.1 - Permission Gate Screen

### DIFF
--- a/app/src/main/java/com/brainrotrpg/PermissionScreen.kt
+++ b/app/src/main/java/com/brainrotrpg/PermissionScreen.kt
@@ -1,0 +1,81 @@
+package com.brainrotrpg
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.brainrotrpg.ui.theme.BrainRotRPGTheme
+
+@Composable
+fun PermissionScreen(
+    onPermissionGranted: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                if (UsagePermissionHelper.hasUsagePermission(context)) {
+                    onPermissionGranted()
+                }
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = stringResource(R.string.permission_title),
+            style = MaterialTheme.typography.headlineMedium,
+            textAlign = TextAlign.Center
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = stringResource(R.string.permission_explanation),
+            style = MaterialTheme.typography.bodyLarge,
+            textAlign = TextAlign.Center
+        )
+        Spacer(modifier = Modifier.height(32.dp))
+        Button(
+            onClick = { UsagePermissionHelper.openUsageAccessSettings(context) }
+        ) {
+            Text(text = stringResource(R.string.permission_cta))
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PermissionScreenPreview() {
+    BrainRotRPGTheme {
+        PermissionScreen(onPermissionGranted = {})
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">BrainRot RPG</string>
+    <string name="permission_title">Usage Access Required</string>
+    <string name="permission_explanation">BrainRot RPG needs permission to read your app usage stats. This lets us track your screen time and evolve your avatar based on how you use your phone.</string>
+    <string name="permission_cta">Enable Usage Access</string>
 </resources>


### PR DESCRIPTION
Implements Task 6.1 from TASKS.md: creates PermissionScreen composable with lifecycle-aware permission re-check on resume.

Closes #37

Generated with [Claude Code](https://claude.ai/code)