### PR TITLE
feat: Phase 8 — Room Objects & XP Multiplier Data Layer

### DIFF
--- a/app/src/main/java/com/brainrotrpg/AppDatabase.kt
+++ b/app/src/main/java/com/brainrotrpg/AppDatabase.kt
@@ -4,11 +4,12 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 
 @Database(
-    entities = [UsageRecord::class, PlayerStats::class],
-    version = 1,
+    entities = [UsageRecord::class, PlayerStats::class, RoomObject::class],
+    version = 2,           // bumped from 1
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun usageRecordDao(): UsageRecordDao
     abstract fun playerStatsDao(): PlayerStatsDao
+    abstract fun roomObjectDao(): RoomObjectDao
 }

--- a/app/src/main/java/com/brainrotrpg/DatabaseProvider.kt
+++ b/app/src/main/java/com/brainrotrpg/DatabaseProvider.kt
@@ -2,6 +2,27 @@ package com.brainrotrpg
 
 import android.content.Context
 import androidx.room.Room
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val MIGRATION_1_2 = object : Migration(1, 2) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("""
+            CREATE TABLE IF NOT EXISTS room_objects (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                type TEXT NOT NULL,
+                worldX REAL NOT NULL,
+                worldY REAL NOT NULL,
+                isActive INTEGER NOT NULL DEFAULT 0,
+                activatedAt INTEGER NOT NULL DEFAULT 0,
+                activeDurationMs INTEGER NOT NULL DEFAULT 14400000
+            )
+        """)
+        database.execSQL("ALTER TABLE player_stats ADD COLUMN spendableBrainrotHours REAL NOT NULL DEFAULT 0")
+        database.execSQL("ALTER TABLE player_stats ADD COLUMN spendableMidHours REAL NOT NULL DEFAULT 0")
+        database.execSQL("ALTER TABLE player_stats ADD COLUMN spendableEnrichmentHours REAL NOT NULL DEFAULT 0")
+    }
+}
 
 object DatabaseProvider {
     private const val DATABASE_NAME = "brainrot_rpg.db"
@@ -15,7 +36,9 @@ object DatabaseProvider {
                 context.applicationContext,
                 AppDatabase::class.java,
                 DATABASE_NAME
-            ).build().also { instance = it }
+            )
+            .addMigrations(MIGRATION_1_2)
+            .build().also { instance = it }
         }
     }
 }

--- a/app/src/main/java/com/brainrotrpg/PlayerStats.kt
+++ b/app/src/main/java/com/brainrotrpg/PlayerStats.kt
@@ -9,8 +9,11 @@ data class PlayerStats(
     val id: Int = 1, // Singleton row — always 1
     val totalXp: Long,
     val level: Int,
-    val brainrotHours: Float,
+    val brainrotHours: Float,       // cumulative — used for avatar class
     val midHours: Float,
     val enrichmentHours: Float,
+    val spendableBrainrotHours: Float = 0f,   // spendable currency
+    val spendableMidHours: Float = 0f,
+    val spendableEnrichmentHours: Float = 0f,
     val lastCheckedTimestamp: Long
 )

--- a/app/src/main/java/com/brainrotrpg/RoomObject.kt
+++ b/app/src/main/java/com/brainrotrpg/RoomObject.kt
@@ -1,0 +1,26 @@
+package com.brainrotrpg
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "room_objects")
+data class RoomObject(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val type: String,               // RoomObjectType.name — stored as string for Room compatibility
+    val worldX: Float,              // normalised world position (0f..1f)
+    val worldY: Float,
+    val isActive: Boolean = false,
+    val activatedAt: Long = 0L,     // timestamp of last tap activation
+    val activeDurationMs: Long = 4 * 60 * 60 * 1000L  // 4 hours default
+)
+
+fun RoomObject.objectType(): RoomObjectType = RoomObjectType.valueOf(type)
+
+fun RoomObject.isCurrentlyActive(now: Long = System.currentTimeMillis()): Boolean {
+    return isActive && (activatedAt + activeDurationMs) > now
+}
+
+fun RoomObject.timeRemainingMs(now: Long = System.currentTimeMillis()): Long {
+    return if (isCurrentlyActive(now)) (activatedAt + activeDurationMs) - now else 0L
+}

--- a/app/src/main/java/com/brainrotrpg/RoomObjectDao.kt
+++ b/app/src/main/java/com/brainrotrpg/RoomObjectDao.kt
@@ -1,0 +1,34 @@
+package com.brainrotrpg
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Update
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface RoomObjectDao {
+
+    @Insert
+    suspend fun insert(obj: RoomObject): Long
+
+    @Update
+    suspend fun update(obj: RoomObject)
+
+    @Delete
+    suspend fun delete(obj: RoomObject)
+
+    @Query("SELECT * FROM room_objects")
+    fun observeAll(): Flow<List<RoomObject>>
+
+    @Query("SELECT * FROM room_objects")
+    suspend fun getAll(): List<RoomObject>
+
+    @Query("SELECT * FROM room_objects WHERE id = :id")
+    suspend fun getById(id: Long): RoomObject?
+
+    // Returns all objects where the active window has not yet expired
+    @Query("SELECT * FROM room_objects WHERE isActive = 1 AND (activatedAt + activeDurationMs) > :now")
+    suspend fun getActiveObjects(now: Long = System.currentTimeMillis()): List<RoomObject>
+}

--- a/app/src/main/java/com/brainrotrpg/RoomObjectType.kt
+++ b/app/src/main/java/com/brainrotrpg/RoomObjectType.kt
@@ -1,0 +1,65 @@
+package com.brainrotrpg
+
+data class XpMultipliers(
+    val brainrot: Float = 1f,
+    val mid: Float = 1f,
+    val enrichment: Float = 1f
+)
+
+enum class RoomObjectType(
+    val displayName: String,
+    val emoji: String,
+    val costCategory: Category,
+    val costHours: Float,
+    val multipliers: XpMultipliers,
+    val description: String
+) {
+    WEIGHTS(
+        displayName = "Weights",
+        emoji = "🏋️",
+        costCategory = Category.ENRICHMENT,
+        costHours = 2f,
+        multipliers = XpMultipliers(brainrot = 1f, mid = 1f, enrichment = 1.15f),
+        description = "+15% all XP while active"
+    ),
+    BOOKSHELF(
+        displayName = "Bookshelf",
+        emoji = "📚",
+        costCategory = Category.ENRICHMENT,
+        costHours = 3f,
+        multipliers = XpMultipliers(brainrot = 1f, mid = 1f, enrichment = 1.25f),
+        description = "+25% Enrichment XP while active"
+    ),
+    SECOND_MONITOR(
+        displayName = "Second Monitor",
+        emoji = "🖥️",
+        costCategory = Category.MID,
+        costHours = 2f,
+        multipliers = XpMultipliers(brainrot = 1f, mid = 1.20f, enrichment = 1f),
+        description = "+20% Mid XP while active"
+    ),
+    PIZZA_TOWER(
+        displayName = "Pizza Tower",
+        emoji = "🍕",
+        costCategory = Category.BRAINROT,
+        costHours = 2f,
+        multipliers = XpMultipliers(brainrot = 1.20f, mid = 1f, enrichment = 1f),
+        description = "+20% Brainrot XP while active"
+    ),
+    ENERGY_FRIDGE(
+        displayName = "Energy Fridge",
+        emoji = "⚡",
+        costCategory = Category.BRAINROT,
+        costHours = 3f,
+        multipliers = XpMultipliers(brainrot = 1.15f, mid = 1.15f, enrichment = 0.90f),
+        description = "+15% Brainrot & Mid XP, -10% Enrichment while active"
+    ),
+    HEADPHONE_STAND(
+        displayName = "Headphone Stand",
+        emoji = "🎧",
+        costCategory = Category.ENRICHMENT,
+        costHours = 2f,
+        multipliers = XpMultipliers(brainrot = 1f, mid = 1f, enrichment = 1.20f),
+        description = "+20% Enrichment XP while active"
+    )
+}

--- a/app/src/main/java/com/brainrotrpg/UsageTrackingWorker.kt
+++ b/app/src/main/java/com/brainrotrpg/UsageTrackingWorker.kt
@@ -53,7 +53,42 @@ class UsageTrackingWorker(
             val newMidHours = (currentStats?.midHours ?: 0f) + midDeltaHours
             val newEnrichmentHours = (currentStats?.enrichmentHours ?: 0f) + enrichmentDeltaHours
 
-            val newTotalXp = XpEngine.calculateXp(newBrainrotHours, newMidHours, newEnrichmentHours)
+            // Accumulate spendable hours
+            val newSpendableBrainrot = (currentStats?.spendableBrainrotHours ?: 0f) + brainrotDeltaHours
+            val newSpendableMid = (currentStats?.spendableMidHours ?: 0f) + midDeltaHours
+            val newSpendableEnrichment = (currentStats?.spendableEnrichmentHours ?: 0f) + enrichmentDeltaHours
+
+            // Fetch active room objects and aggregate multipliers
+            val roomObjectDao = db.roomObjectDao()
+            val activeObjects = roomObjectDao.getActiveObjects(now)
+
+            // Expire any objects whose window has closed since last check
+            val allObjects = roomObjectDao.getAll()
+            for (obj in allObjects) {
+                if (obj.isActive && !obj.isCurrentlyActive(now)) {
+                    roomObjectDao.update(obj.copy(isActive = false))
+                }
+            }
+
+            // Aggregate multipliers (multiplicative stacking)
+            var brainrotMultiplier = 1f
+            var midMultiplier = 1f
+            var enrichmentMultiplier = 1f
+            for (obj in activeObjects) {
+                val m = obj.objectType().multipliers
+                brainrotMultiplier *= m.brainrot
+                midMultiplier *= m.mid
+                enrichmentMultiplier *= m.enrichment
+            }
+
+            val newTotalXp = XpEngine.calculateXpWithMultipliers(
+                brainrotHours = newBrainrotHours,
+                midHours = newMidHours,
+                enrichmentHours = newEnrichmentHours,
+                brainrotMultiplier = brainrotMultiplier,
+                midMultiplier = midMultiplier,
+                enrichmentMultiplier = enrichmentMultiplier
+            )
             val newLevel = XpEngine.calculateLevel(newTotalXp)
 
             val updatedStats = PlayerStats(
@@ -63,6 +98,9 @@ class UsageTrackingWorker(
                 brainrotHours = newBrainrotHours,
                 midHours = newMidHours,
                 enrichmentHours = newEnrichmentHours,
+                spendableBrainrotHours = newSpendableBrainrot,
+                spendableMidHours = newSpendableMid,
+                spendableEnrichmentHours = newSpendableEnrichment,
                 lastCheckedTimestamp = now
             )
             playerStatsDao.upsert(updatedStats)

--- a/app/src/main/java/com/brainrotrpg/XpEngine.kt
+++ b/app/src/main/java/com/brainrotrpg/XpEngine.kt
@@ -22,6 +22,20 @@ object XpEngine {
         return (totalHours * XP_PER_HOUR).toLong()
     }
 
+    fun calculateXpWithMultipliers(
+        brainrotHours: Float,
+        midHours: Float,
+        enrichmentHours: Float,
+        brainrotMultiplier: Float = 1f,
+        midMultiplier: Float = 1f,
+        enrichmentMultiplier: Float = 1f
+    ): Long {
+        val xp = (brainrotHours * XP_PER_HOUR * brainrotMultiplier) +
+                  (midHours * XP_PER_HOUR * midMultiplier) +
+                  (enrichmentHours * XP_PER_HOUR * enrichmentMultiplier)
+        return xp.toLong()
+    }
+
     fun calculateLevel(totalXp: Long): Int {
         var level = 1
         for (i in LEVEL_THRESHOLDS.indices) {


### PR DESCRIPTION
Implements Phase 8 tasks 8.1–8.5 from TASKS-ROOM-OBJECTS.md:

- RoomObjectType enum with XpMultipliers
- RoomObject entity and RoomObjectDao
- Database migration v1→v2 (room_objects table + spendable hour columns)
- PlayerStats spendable hour fields
- UsageTrackingWorker multiplier logic and XpEngine.calculateXpWithMultipliers()

Closes #47

Generated with [Claude Code](https://claude.ai/code)