### PR TITLE
feat: Phase 13 Task 13.1 - Hook Lifecycle Detection into UsageTrackingWorker

### DIFF
--- a/app/src/main/java/com/brainrotrpg/UsageTrackingWorker.kt
+++ b/app/src/main/java/com/brainrotrpg/UsageTrackingWorker.kt
@@ -101,8 +101,27 @@ class UsageTrackingWorker(
                 spendableBrainrotHours = newSpendableBrainrot,
                 spendableMidHours = newSpendableMid,
                 spendableEnrichmentHours = newSpendableEnrichment,
-                lastCheckedTimestamp = now
+                lastCheckedTimestamp = now,
+                lifecycleNumber = currentStats?.lifecycleNumber ?: 1,
+                lifecycleStartedAt = currentStats?.lifecycleStartedAt ?: now,
+                pendingLifecycleEnd = false
             )
+
+            if (LifecycleEngine.isLifecycleComplete(newTotalXp) && !(currentStats?.pendingLifecycleEnd ?: false)) {
+                // Snapshot the completed lifecycle
+                val roomObjectsPlaced = allObjects.size
+                val record = LifecycleEngine.buildRecord(updatedStats, roomObjectsPlaced, endedAt = now)
+                db.lifecycleRecordDao().insert(record)
+
+                // Mark pendingLifecycleEnd so the UI can show the end screen
+                // Do NOT reset yet — reset happens when the player taps "Begin New Life"
+                playerStatsDao.upsert(updatedStats.copy(pendingLifecycleEnd = true))
+
+                Log.d(TAG, "Lifecycle ${record.lifecycleNumber} complete. Outcome: ${record.outcome}")
+                return Result.success()
+            }
+
+            // Normal write path (lifecycle not yet complete)
             playerStatsDao.upsert(updatedStats)
 
             Log.d(TAG, "Usage tracking complete. XP: $newTotalXp, Level: $newLevel")


### PR DESCRIPTION
Implements task 13.1 from TASKS-LIFECYCLE.md.

Hooks `LifecycleEngine` into `UsageTrackingWorker` so that when XP reaches 16,000, a `LifecycleRecord` is written and `pendingLifecycleEnd` is set to `true`. A guard prevents the lifecycle from triggering again on subsequent worker runs while pending.

Closes #56

Generated with [Claude Code](https://claude.ai/code)